### PR TITLE
Update lxc-iptag

### DIFF
--- a/lxc-iptag
+++ b/lxc-iptag
@@ -85,7 +85,7 @@ main() {
             echo "Setting ${lxc_name} tags from ${old_tags} to ${joined_tags}"
             pct set "${lxc_name}" -tags "${joined_tags}"
         done
-        sleep 60
+        sleep 1800
     done
 }
 


### PR DESCRIPTION
I don't think there is much reason to run this every 60 seconds. I suggest increasing it to 30 minutes.